### PR TITLE
Add a C API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+drat-trim
+drat-trim.a
+drat-trim.o

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 drat-trim
 drat-trim.a
 drat-trim.o
+install

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,15 @@ drat-trim.o: drat-trim.c drat-trim.h
 drat-trim.a: drat-trim.o
 	ar rc $@ $^
 
+install: drat-trim.a drat-trim.h drat-trim
+	mkdir -p install/lib
+	mkdir -p install/include
+	mkdir -p install/bin
+	cp drat-trim.a install/lib
+	cp drat-trim.h install/include
+	cp drat-trim install/bin
+
 clean:
-	rm -f drat-trim drat-trim.o drat-trim.a
+	rm -rf drat-trim drat-trim.o drat-trim.a install
+
+

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ drat-trim: main.c drat-trim.o
 	gcc main.c -O2 -o drat-trim drat-trim.o
 
 drat-trim.o: drat-trim.c drat-trim.h
-	gcc drat-trim.c -O2 -c -o drat-trim.o
+	gcc -fPIC drat-trim.c -O2 -c -o drat-trim.o
 
 drat-trim.a: drat-trim.o
 	ar rc $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
-drat-trim: drat-trim.c
-	gcc drat-trim.c -O2 -o drat-trim
+drat-trim: main.c drat-trim.o
+	gcc main.c -O2 -o drat-trim drat-trim.o
+
+drat-trim.o: drat-trim.c drat-trim.h
+	gcc drat-trim.c -O2 -c -o drat-trim.o
+
+drat-trim.a: drat-trim.o
+	ar rc $@ $^
 
 clean:
-	rm drat-trim	
+	rm -f drat-trim drat-trim.o drat-trim.a

--- a/drat-trim.c
+++ b/drat-trim.c
@@ -24,6 +24,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <assert.h>
 #include <sys/time.h>
 
+#include "drat-trim.h"
+
 #define TIMEOUT     20000
 #define BIGINIT     1000000
 #define INIT        4
@@ -1500,7 +1502,7 @@ void printHelp ( ) {
   printf ("  PROOF       proof file in DRAT format (stdin if no argument)\n\n");
   exit (0); }
 
-int main (int argc, char** argv) {
+int run_drat_trim (int argc, char** argv) {
   struct solver S;
 
   S.inputFile  = NULL;

--- a/drat-trim.h
+++ b/drat-trim.h
@@ -1,0 +1,27 @@
+/************************************************************************************[drat-trim.c]
+Copyright (c) 2014 Marijn Heule and Nathan Wetzler, The University of Texas at Austin.
+Copyright (c) 2015-2017 Marijn Heule, The University of Texas at Austin.
+Last edit, December 21, 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**************************************************************************************************/
+
+#pragma once
+
+/**
+ * Equivalent to invoking drat-trim with the indicated arguments
+ */
+int run_drat_trim (int argc, char** argv);

--- a/main.c
+++ b/main.c
@@ -1,0 +1,26 @@
+/************************************************************************************[drat-trim.c]
+Copyright (c) 2014 Marijn Heule and Nathan Wetzler, The University of Texas at Austin.
+Copyright (c) 2015-2017 Marijn Heule, The University of Texas at Austin.
+Last edit, December 21, 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**************************************************************************************************/
+
+#include "drat-trim.h"
+
+int main (int argc, char** argv) {
+  return run_drat_trim(argc, argv);
+}


### PR DESCRIPTION
Creates a C API by exposing a  function, `run_drat_trim` with identical behavior to the command-line tool drat-trim.

Credits to @benjaminkiesl, since this design is taken from his drat2er tool.