### PR TITLE
Better binary detection

### DIFF
--- a/drat-trim.c
+++ b/drat-trim.c
@@ -1568,14 +1568,14 @@ int main (int argc, char** argv) {
        if (S.binMode == 0) {
           c = getc_unlocked (S.proofFile); // check the first character in the file
           if (c == EOF) { S.binMode = 1; continue; }
-          if ((c != 13) && (c != 32) && (c != 45) && ((c < 48) || (c > 57)) && (c != 99) && (c != 100)) {
+          if ((c != 10) && (c != 13) && (c != 32) && (c != 45) && ((c < 48) || (c > 57)) && (c != 99) && (c != 100)) {
              printf ("\rc turning on binary mode checking\n");
              S.binMode = 1; }
           if (c != 99) comment = 0; }
         if (S.binMode == 0) {
           c = getc_unlocked (S.proofFile); // check the second character in the file
           if (c == EOF) { S.binMode = 1; continue; }
-          if ((c != 13) && (c != 32) && (c != 45) && ((c < 48) || (c > 57)) && (c != 99) && (c != 100)) {
+          if ((c != 10) && (c != 13) && (c != 32) && (c != 45) && ((c < 48) || (c > 57)) && (c != 99) && (c != 100)) {
              printf ("\rc turning on binary mode checking\n");
              S.binMode = 1; }
           if (c != 32) comment = 0; }


### PR DESCRIPTION
The binary detection essentially looks at the first few characters and
tries to determine whether they're ASCII characters which are
appropriate for a DRAT proof. However, it forgot that newlines (0x0a)
are ASCII characters which are appropriate for DRAT proofs.

A minimal example that used to fail, but now does not:

Formula:
```
p cnf 1 2
1 0
-1 0
```

Proof:
```
0
```

where the newline are 0x0a.