### PR TITLE
fix infinite loop bug in lrat-check

### DIFF
--- a/lrat-check.c
+++ b/lrat-check.c
@@ -259,13 +259,13 @@ int main (int argc, char** argv) {
       printf("Couldn't open file '%s'\n", argv[1]);
       exit(1); }
 
-  for (;;) {
-    fscanf (cnf, " p cnf %i %i ", &nVar, &nCls);
-    if (nVar > 0) break;
+  while (fscanf (cnf, " p cnf %i %i ", &nVar, &nCls) != 2) {
     fgets (ignore, sizeof (ignore), cnf);
     int j; for (j = 0; j < 1024; j++) { if (ignore[j] == '\n') break; }
     if (j == 1024) {
       printf ("c ERROR: comment longer than 1024 characters: %s\n", ignore); exit (0); } }
+
+  if (nVar <= 0) nVar = 1;
 
   clsAlloc = nCls * 2;
   clsList  = (int*) malloc (sizeof(int) * clsAlloc);


### PR DESCRIPTION
This would go into an infinite loop if it encounters `p cnf 0 0`,
because the first fscanf would succeed but since nVar is set to 0 it
doesn't proceed; and later iterations return 0 from `fscanf` because it
doesn't parse, but the return value isn't being checked so it just
hangs.

fixes #21