### PR TITLE
[lrat-check] Return 0 only if empty clause was derived; always provide feedback

### DIFF
--- a/lrat-check.c
+++ b/lrat-check.c
@@ -364,7 +364,8 @@ int main (int argc, char** argv) {
   if (argc < 3)
      usage(argv[0]);
   struct timeval start_time, finish_time;
-  int return_code = 0;
+  int found_error = 0; // encountered an error?
+  int found_empty_clause = 0; // encountered derivation of empty clause?
   gettimeofday(&start_time, NULL);
   now = 0, clsLast = 0;
 
@@ -451,17 +452,30 @@ int main (int argc, char** argv) {
       else {
         printf("c failed while checking clause: "); printClause (litList + 2);
         checkClause (litList + 2, length, hints, 1);
-        printf("c NOT VERIFIED\n");
-        return_code = 1;
+        found_error = 1;
         break;
       }
       if (length == 0)
-        printf ("c VERIFIED\n");
+        found_empty_clause = 1;
     }
     else {
       printf ("c failed type\n");
-      return_code = 1;
+      found_error = 1;
+      break;
     }
+  }
+
+  int return_code;
+  if (found_empty_clause && !found_error) {
+    printf ("c VERIFIED\n");
+    return_code = 0;
+  } else {
+    if (!found_error) {
+      // print why the proof failed
+      printf ("c checking ended before empty clause was found\n");
+    }
+    printf ("c NOT VERIFIED\n");
+    return_code = 1;
   }
 
   printf ("c allocated %i %i %i\n", maxBucket, tableAlloc, litAlloc);


### PR DESCRIPTION
As of now, `lrat-check` silently exits with return value 0 as long as all line types were parsed correctly and no wrong clause was found – even if no empty clause was found or if it failed to parse a proof line.

I suggest to have the program exit with 1 and output `c NOT VERIFIED` by default, _unless_ both (a) the empty clause was found _and_ (b) no error occurred until then. This makes the checker more reliable to use as a part of a pipeline.

I tested the changes on a correct proof, a truncated proof, and a syntactically broken proof.