### PR TITLE
Variable type update

### DIFF
--- a/drat-trim.c
+++ b/drat-trim.c
@@ -1092,7 +1092,7 @@ int parse (struct solver* S) {
     hashTable[i] = (long*) malloc (sizeof (long) * hashMax[i]); }
 
   int fileSwitchFlag = 0;
-  int finalClause = 0;
+  long finalClause = 0;
   size = 0;
   while (1) {
     int lit = 0; tmp = 0;


### PR DESCRIPTION
Hi Marijn, yesterday I ran into a segfault when parsing proofs with too many clauses and tracked it down to an int variable overflowing - here's a fix.