### PR TITLE
drat-trim.c, decompress.c: fix `gcc-14` build

### DIFF
--- a/decompress.c
+++ b/decompress.c
@@ -18,6 +18,9 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+// get 'getc_unlocked' on glibc
+#define _POSIX_C_SOURCE 199506L
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/drat-trim.c
+++ b/drat-trim.c
@@ -19,6 +19,9 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+// get 'getc_unlocked' on glibc
+#define _POSIX_C_SOURCE 199506L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>


### PR DESCRIPTION
Without the change the build on `gcc-14` fails as:

    drat-trim.c: In function 'read_lit':
    drat-trim.c:989:10: error: implicit declaration of function 'getc_unlocked' [-Wimplicit-function-declaration]
      989 |     lc = getc_unlocked (S->proofFile);
          |          ^~~~~~~~~~~~
